### PR TITLE
Fix alt text in analytics image

### DIFF
--- a/Analytics.html
+++ b/Analytics.html
@@ -402,7 +402,7 @@
         <div class="budget-card">
           <img
             src="Images/undraw_online-calendar_zaoc.png"
-            alt="Analytics Image"
+            alt="Online calendar illustration"
             class="top-card-image"
           />
           <div style="display: flex; flex-direction: column; gap: 1rem; width: 100%;">


### PR DESCRIPTION
## Summary
- improve alt text for the analytics image so screen readers describe the content

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f773a51308320bc2643986e332e17