### PR TITLE
Fix goal text sanitization

### DIFF
--- a/Goals & Categories.html
+++ b/Goals & Categories.html
@@ -347,6 +347,11 @@
       });
     }
 
+    // Strip any HTML tags from user-provided text
+    function sanitizeText(text) {
+      return text.replace(/<[^>]*>/g, '');
+    }
+
     // Goals and Categories stored in localStorage
     let storedGoals = localStorage.getItem('goals');
       let goals = storedGoals ? JSON.parse(storedGoals) : [
@@ -581,11 +586,12 @@
         if (goal) {
           let newTitle = prompt("Edit goal title:", goal.title);
           if (newTitle === null) return;
-          newTitle = newTitle.trim();
+          newTitle = sanitizeText(newTitle.trim());
           if (newTitle === "") newTitle = goal.title;
 
           let newDesc = prompt("Edit goal description:", goal.description);
           if (newDesc === null) return;
+          newDesc = sanitizeText(newDesc.trim());
 
         let newCurrent = promptNumber("Edit current saved amount (current: " + goal.current + "):");
         if (newCurrent === null) return;
@@ -687,8 +693,8 @@
       }
       const newGoal = {
         id: generateId(),
-        title: title.trim(),
-        description: description || "",
+        title: sanitizeText(title.trim()),
+        description: description ? sanitizeText(description.trim()) : "",
         current: current,
         target: target
       };


### PR DESCRIPTION
## Summary
- prevent HTML tags from being stored in financial goal titles or descriptions
- sanitize goal title/description when adding or editing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f79ae988c8320b2162eb1d193083d